### PR TITLE
feat: enable drag reordering for questions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",
+    "framer-motion": "^11.0.0",
     "vite": "^5.4.19"
   },
   "devDependencies": {

--- a/frontend/src/views/EditView.tsx
+++ b/frontend/src/views/EditView.tsx
@@ -119,7 +119,7 @@ const addQuestion = (sectionIndex: number, afterQuestionIndex: number) => {
 
 
   // Add a new section
-  const addSection = () => {
+const addSection = () => {
     const newSection = {
       passage: "",
       questions: [createEmptyQuestion()]
@@ -130,9 +130,33 @@ const addQuestion = (sectionIndex: number, afterQuestionIndex: number) => {
     onUpdateSection(newSectionIndex, newSection);
 
     // Switch to the new section
-    setCurrentSectionIndex(newSectionIndex);
-    setCurrentQuestionIndex(0);
-  };
+  setCurrentSectionIndex(newSectionIndex);
+  setCurrentQuestionIndex(0);
+};
+
+const reorderQuestions = (sectionIdx: number, newQuestions: Question[]) => {
+  const updatedSection = { ...safeSections[sectionIdx], questions: newQuestions };
+  onUpdateSection(sectionIdx, updatedSection);
+
+  if (sectionIdx === currentSectionIndex) {
+    const newIndex = newQuestions.indexOf(currentQuestion);
+    setCurrentQuestionIndex(newIndex);
+  }
+};
+
+const reorderSections = (newSections: Section[]) => {
+  setAppState(prev => {
+    const activeId = prev.activeTestId!;
+    const active = prev.tests[activeId];
+    return {
+      ...prev,
+      tests: { ...prev.tests, [activeId]: { ...active, sections: newSections } }
+    };
+  });
+
+  const newIndex = newSections.indexOf(safeSections[currentSectionIndex]);
+  setCurrentSectionIndex(newIndex);
+};
 
   return (
     <div style={{ display: "block" }}>
@@ -180,6 +204,8 @@ const addQuestion = (sectionIndex: number, afterQuestionIndex: number) => {
         isEditView={true}
         onAddQuestion={addQuestion}
         onAddSection={addSection}
+        onReorderQuestions={reorderQuestions}
+        onReorderSections={reorderSections}
       />
 
     </div>


### PR DESCRIPTION
## Summary
- add framer-motion dependency
- enable question and section drag reordering in QuestionNavigation with active selection and hidden add button during drag
- wire EditView to persist reordered questions and sections

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 16 errors, see log)*
- `npm run build` *(fails: Cannot find module 'framer-motion' and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fd1dec8548325a51150da755ab5bf