### PR TITLE
feat: enable test upload and download

### DIFF
--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -73,7 +73,7 @@ h1 {
   margin-bottom: 15px;
 }
 
-.create-test-btn, .toggle-dropdown-btn {
+.create-test-btn, .toggle-dropdown-btn, .upload-test-btn {
   padding: 8px 15px;
   background-color: #333;
   color: white;
@@ -83,7 +83,7 @@ h1 {
   transition: background-color 0.2s;
 }
 
-.create-test-btn:hover, .toggle-dropdown-btn:hover {
+.create-test-btn:hover, .toggle-dropdown-btn:hover, .upload-test-btn:hover {
   background-color: #444;
 }
 


### PR DESCRIPTION
## Summary
- add download option to each test card and export tests as JSON
- allow uploading tests from JSON on the home screen
- style upload button alongside existing actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 16 errors, 1 warning)
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa19c493448325a0f896bd30222ae2