### PR TITLE
Store full session state

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,130 @@
-from fastapi import FastAPI
+"""FastAPI backend providing collaborative session functionality."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+
 
 app = FastAPI()
 
 
+# ---------------------------------------------------------------------------
+# In-memory session management
+# ---------------------------------------------------------------------------
+
+
+class Session:
+    """Simple in-memory representation of a collaborative session."""
+
+    def __init__(self, host_token: str) -> None:
+        self.host_token = host_token
+        self.participants: set[str] = set()
+        self.connections: Dict[str, WebSocket] = {}
+        # store the entire shared application state for the session
+        self.state: dict = {}
+
+
+# session_id -> Session
+SESSIONS: Dict[str, Session] = {}
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.post("/sessions")
+async def create_session() -> dict:
+    """Create a new collaborative session and return identifiers."""
+    session_id = uuid.uuid4().hex
+    host_token = uuid.uuid4().hex
+    SESSIONS[session_id] = Session(host_token=host_token)
+    return {"session_id": session_id, "host_token": host_token}
+
+
+@app.post("/sessions/{session_id}/join")
+async def join_session(session_id: str) -> dict:
+    """Join an existing session and receive a participant token."""
+    session = SESSIONS.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    participant_token = uuid.uuid4().hex
+    session.participants.add(participant_token)
+    return {"participant_token": participant_token}
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint
+# ---------------------------------------------------------------------------
+
+
+async def broadcast(session: Session, message: dict) -> None:
+    """Broadcast a message to all connected clients of a session."""
+    disconnected = []
+    for token, connection in session.connections.items():
+        try:
+            await connection.send_json(message)
+        except WebSocketDisconnect:
+            disconnected.append(token)
+
+    for token in disconnected:
+        session.connections.pop(token, None)
+
+
+@app.websocket("/ws/{session_id}")
+async def session_ws(websocket: WebSocket, session_id: str, token: str) -> None:
+    """Handle websocket connections for a session."""
+    session = SESSIONS.get(session_id)
+    if session is None:
+        await websocket.close(code=4004)
+        return
+
+    # validate token
+    if token != session.host_token and token not in session.participants:
+        await websocket.close(code=4401)
+        return
+
+    await websocket.accept()
+    session.connections[token] = websocket
+
+    # send current state
+    await websocket.send_json({"type": "state", "state": session.state})
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+            msg_type = data.get("type")
+
+            if msg_type == "state":
+                # replace the session's shared state with the provided one
+                session.state = data.get("state", {})
+                # broadcast the authoritative state to all clients
+                await broadcast(session, {"type": "state", "state": session.state})
+            else:
+                # forward any other message types unchanged
+                await broadcast(session, data)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        session.connections.pop(token, None)
+        session.participants.discard(token)
+
+
+# ---------------------------------------------------------------------------
+# Basic sanity check endpoints
+# ---------------------------------------------------------------------------
+
+
 @app.get("/")
-async def root():
+async def root() -> dict:
     return {"message": "Hello World"}
 
 
 @app.get("/hello/{name}")
-async def say_hello(name: str):
+async def say_hello(name: str) -> dict:
     return {"message": f"Hello {name}"}
+

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def create_session_and_join():
+    resp = client.post('/sessions')
+    data = resp.json()
+    session_id = data['session_id']
+    host_token = data['host_token']
+    join_resp = client.post(f'/sessions/{session_id}/join')
+    participant_token = join_resp.json()['participant_token']
+    return session_id, host_token, participant_token
+
+
+def test_create_and_join_session():
+    session_id, host_token, participant_token = create_session_and_join()
+    assert session_id
+    assert host_token
+    assert participant_token
+
+
+def test_websocket_state_sync():
+    session_id, host_token, participant_token = create_session_and_join()
+    with client.websocket_connect(f"/ws/{session_id}?token={host_token}") as host_ws, \
+            client.websocket_connect(f"/ws/{session_id}?token={participant_token}") as user_ws:
+        # initial state is empty for both clients
+        assert host_ws.receive_json() == {"type": "state", "state": {}}
+        assert user_ws.receive_json() == {"type": "state", "state": {}}
+
+        new_state = {"timer": 123, "search": "logic", "highlights": [1, 2]}
+        host_ws.send_json({"type": "state", "state": new_state})
+        message = user_ws.receive_json()
+        assert message["type"] == "state"
+        assert message["state"] == new_state

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,8 +54,8 @@ export default function App() {
       onUpdate={(sectionIndex, questionIndex, updatedQuestion) =>
         updateQuestion(sectionIndex, questionIndex, updatedQuestion)
       }
+      sessionInfo={appState.sessionInfo}
       setAppState={(updaterFn) => setAppState(prevState => updaterFn(prevState))}
-
     />
   )}
 

--- a/frontend/src/Types.tsx
+++ b/frontend/src/Types.tsx
@@ -21,10 +21,14 @@ export type Section = {
 
 export type CollaborativeSession = {
   sessionId: string;
+  /** Token returned from backend for websocket authentication */
+  token: string;
   role: "tutor" | "student";
   connectedUsers: string[];
   lastSynced: number;
   sharedTestId: string;
+  /** Optional state used when the user is not the host */
+  sessionState?: any;
 };
 
 export type Test = {

--- a/frontend/src/session/client.ts
+++ b/frontend/src/session/client.ts
@@ -1,0 +1,41 @@
+export type SessionEvent =
+  | { type: 'timer'; remaining: number }
+  | { type: 'highlight'; highlight: any }
+  | { type: 'search'; term: string };
+
+export type SessionConnection = {
+  send: (event: SessionEvent) => void;
+  close: () => void;
+};
+
+export function connectSession(
+  sessionId: string,
+  token: string,
+  onEvent: (event: SessionEvent) => void
+): SessionConnection {
+  const ws = new WebSocket(`ws://localhost:8000/ws/${sessionId}?token=${token}`);
+  ws.onmessage = (evt) => {
+    try {
+      const data = JSON.parse(evt.data);
+      onEvent(data as SessionEvent);
+    } catch (err) {
+      console.error('Failed to parse session message', err);
+    }
+  };
+  return {
+    send: (event: SessionEvent) => ws.readyState === WebSocket.OPEN && ws.send(JSON.stringify(event)),
+    close: () => ws.close(),
+  };
+}
+
+export async function createSession() {
+  const resp = await fetch('/sessions', { method: 'POST' });
+  if (!resp.ok) throw new Error('Failed to create session');
+  return resp.json() as Promise<{ session_id: string; host_token: string }>;
+}
+
+export async function joinSession(sessionId: string) {
+  const resp = await fetch(`/sessions/${sessionId}/join`, { method: 'POST' });
+  if (!resp.ok) throw new Error('Failed to join session');
+  return resp.json() as Promise<{ participant_token: string }>;
+}

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -1,5 +1,6 @@
 import type { AppState, Test } from "../Types.tsx";
 import { useRef, useState } from "react";
+import { createSession, joinSession } from "../session/client";
 import "../styles/App.css";
 import "../styles/HomeView.css";
 
@@ -15,6 +16,7 @@ export default function HomeView({ appState, setAppState }: Props) {
   const [newTestName, setNewTestName] = useState("");
   const [newTestType, setNewTestType] = useState<"RC" | "LR">("RC");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [joinSessionId, setJoinSessionId] = useState("");
 
   const toggleTestCreation = () => {
     setMainDropdownOpen(false);
@@ -179,6 +181,44 @@ export default function HomeView({ appState, setAppState }: Props) {
     e.target.value = "";
   };
 
+  const handleCreateSession = async () => {
+    try {
+      const data = await createSession();
+      setAppState({
+        ...appState,
+        sessionInfo: {
+          sessionId: data.session_id,
+          token: data.host_token,
+          role: 'tutor',
+          connectedUsers: [],
+          lastSynced: Date.now(),
+          sharedTestId: appState.activeTestId || '',
+        }
+      });
+    } catch (err) {
+      console.error('Failed to create session', err);
+    }
+  };
+
+  const handleJoinSession = async () => {
+    try {
+      const data = await joinSession(joinSessionId);
+      setAppState({
+        ...appState,
+        sessionInfo: {
+          sessionId: joinSessionId,
+          token: data.participant_token,
+          role: 'student',
+          connectedUsers: [],
+          lastSynced: Date.now(),
+          sharedTestId: '',
+        }
+      });
+    } catch (err) {
+      console.error('Failed to join session', err);
+    }
+  };
+
   return (
     <div className="home-view">
       <h1>Welcome to the Test Manager</h1>
@@ -190,6 +230,19 @@ export default function HomeView({ appState, setAppState }: Props) {
 
         <button className="upload-test-btn" onClick={handleUploadClick}>
           Upload Tests
+        </button>
+
+        <button onClick={handleCreateSession}>
+          Start Session
+        </button>
+        <input
+          type="text"
+          placeholder="Session ID"
+          value={joinSessionId}
+          onChange={(e) => setJoinSessionId(e.target.value)}
+        />
+        <button onClick={handleJoinSession}>
+          Join Session
         </button>
 
         {/* Toggle Dropdown Button (appears as "+") */}


### PR DESCRIPTION
## Summary
- Maintain full shared state per session on the backend
- Broadcast authoritative state updates over websockets
- Test websocket state synchronization

## Testing
- `pytest tests/test_sessions.py::test_create_and_join_session -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68aa364c09a88325b79cda0ba2b98294