### PR TITLE
Centralize state updates and broadcast session changes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,87 +1,166 @@
-import {act, useCallback, useState} from "react";
+import { useState, useRef } from "react";
 import "./styles/App.css";
-import type { AppState } from "./Types.tsx";
+import type { AppState, Test, Section, CollaborativeSession, Question } from "./Types.tsx";
 import HomeView from "./views/HomeView";
 import EditView from "./views/EditView";
 import DisplayView from "./views/DisplayView";
-import {multipleTestsEditingState} from "./sampleStates.tsx";
+import { multipleTestsEditingState } from "./sampleStates.tsx";
+import type { SessionEvent } from "./session/client";
 
-
-
-// Main App component
 export default function App() {
-  // Initialize the application's state
   const [appState, setAppState] = useState<AppState>({
-    ...multipleTestsEditingState
+    ...multipleTestsEditingState,
   });
 
-  // const setAppState = (newState: AppState | ((prevState: AppState) => AppState)) => {
-  //   // Call the original setState
-  //   setAppStateInternal(newState);
-  //   if (appState.sessionInfo !== undefined) {
-  //
-  //   }
-  // };
+  const sessionSend = useRef<((event: SessionEvent) => void) | null>(null);
+  const registerSessionSend = (sendFn: ((event: SessionEvent) => void) | null) => {
+    sessionSend.current = sendFn;
+  };
+  const sendStateUpdate = (patch: unknown) => {
+    if (appState.sessionInfo && sessionSend.current) {
+      sessionSend.current({ type: 'state_update', patch });
+    }
+  };
 
-
-  // Get the currently active test based on activeTestId
   const activeTest = appState.activeTestId
     ? appState.tests[appState.activeTestId]
     : null;
 
-  // Update a specific question inside a section
-  const updateQuestion = (sectionIndex: number, questionIndex: number, updatedQuestion: any) => {
+  const updateQuestion = (sectionIndex: number, questionIndex: number, updatedQuestion: Question) => {
     if (!activeTest) return;
-
-    // Spread operator to deep-copy sections and questions
     const updatedSections = [...activeTest.sections];
     updatedSections[sectionIndex].questions[questionIndex] = updatedQuestion;
-
-    // Update the tests object in the global app state
     const updatedTests = { ...appState.tests, [activeTest.id]: { ...activeTest, sections: updatedSections } };
     setAppState({ ...appState, tests: updatedTests });
+    sendStateUpdate({ op: 'updateQuestion', testId: activeTest.id, sectionIndex, questionIndex, question: updatedQuestion });
   };
 
-  const updateTestName = (testId: string, updatedName: any) => {
-    setAppState({ ...appState, tests: { ...appState.tests, [testId]: { ...appState.tests[testId], name: updatedName } } });
-  }
+  const updateTestName = (testId: string, updatedName: string) => {
+    const updatedTests = { ...appState.tests, [testId]: { ...appState.tests[testId], name: updatedName } };
+    setAppState({ ...appState, tests: updatedTests });
+    sendStateUpdate({ op: 'updateTestName', testId, name: updatedName });
+  };
+
+  const updateSection = (index: number, updatedSection: Section) => {
+    if (!activeTest) return;
+    const updatedSections = [...activeTest.sections];
+    updatedSections[index] = updatedSection;
+    const updatedTests = { ...appState.tests, [activeTest.id]: { ...activeTest, sections: updatedSections } };
+    setAppState({ ...appState, tests: updatedTests });
+    sendStateUpdate({ op: 'updateSection', testId: activeTest.id, index, section: updatedSection });
+  };
+
+  const updateSections = (sections: Section[]) => {
+    if (!activeTest) return;
+    const updatedTests = { ...appState.tests, [activeTest.id]: { ...activeTest, sections } };
+    setAppState({ ...appState, tests: updatedTests });
+    sendStateUpdate({ op: 'updateSections', testId: activeTest.id, sections });
+  };
+
+  const createTest = (name: string, type: "RC" | "LR") => {
+    const newTestId = String(Date.now());
+    const newTest: Test = {
+      type,
+      id: newTestId,
+      name,
+      sections: [{ passage: "", questions: [] }],
+    };
+    const newState: AppState = {
+      ...appState,
+      tests: { ...appState.tests, [newTestId]: newTest },
+      activeTestId: newTestId,
+      viewMode: "edit",
+    };
+    setAppState(newState);
+    sendStateUpdate({ op: 'createTest', test: newTest, activeTestId: newTestId });
+  };
+
+  const viewTest = (testId: string) => {
+    setAppState({ ...appState, activeTestId: testId, viewMode: "display" });
+    sendStateUpdate({ op: 'viewTest', testId });
+  };
+
+  const editTest = (testId: string) => {
+    setAppState({ ...appState, activeTestId: testId, viewMode: "edit" });
+    sendStateUpdate({ op: 'editTest', testId });
+  };
+
+  const deleteTest = (testId: string) => {
+    const newTests = { ...appState.tests };
+    delete newTests[testId];
+    setAppState({ ...appState, tests: newTests });
+    sendStateUpdate({ op: 'deleteTest', testId });
+  };
+
+  const importTests = (tests: Record<string, Test>) => {
+    setAppState({ ...appState, tests: { ...appState.tests, ...tests } });
+    sendStateUpdate({ op: 'importTests', tests });
+  };
+
+  const setSessionInfo = (info: CollaborativeSession) => {
+    setAppState({ ...appState, sessionInfo: info });
+    sendStateUpdate({ op: 'setSessionInfo', info });
+  };
+
+  const resetTestProgress = (testId: string) => {
+    const target = appState.tests[testId];
+    if (!target) return;
+    const resetSections = target.sections.map((section) => ({
+      ...section,
+      questions: section.questions.map((q) => ({
+        ...q,
+        selectedChoice: undefined,
+        revealedIncorrectChoice: undefined,
+        eliminatedChoices: undefined,
+      })),
+    }));
+    const updatedTests = { ...appState.tests, [testId]: { ...target, sections: resetSections } };
+    setAppState({ ...appState, tests: updatedTests });
+    sendStateUpdate({ op: 'resetTestProgress', testId });
+  };
+
+  const goHome = () => {
+    setAppState({ ...appState, viewMode: "home", activeTestId: null });
+    sendStateUpdate({ op: 'goHome' });
+  };
 
   return (
     <div className="app-container">
-      {/* Home View */}
       {appState.viewMode === "home" && (
         <HomeView
           appState={appState}
-          setAppState={(newAppState) => setAppState(newAppState)}
+          onCreateTest={createTest}
+          onViewTest={viewTest}
+          onEditTest={editTest}
+          onDeleteTest={deleteTest}
+          onImportTests={importTests}
+          onSetSessionInfo={setSessionInfo}
         />
       )}
 
-  {/* Display View */}
-  {appState.viewMode === "display" && activeTest && (
-    <DisplayView
-      test={activeTest}
-      onUpdate={(sectionIndex, questionIndex, updatedQuestion) =>
-        updateQuestion(sectionIndex, questionIndex, updatedQuestion)
-      }
-      sessionInfo={appState.sessionInfo}
-      setAppState={(updaterFn) => setAppState(prevState => updaterFn(prevState))}
-    />
-  )}
+      {appState.viewMode === "display" && activeTest && (
+        <DisplayView
+          test={activeTest}
+          onUpdate={(sectionIndex, questionIndex, updatedQuestion) =>
+            updateQuestion(sectionIndex, questionIndex, updatedQuestion as Question)
+          }
+          sessionInfo={appState.sessionInfo}
+          onResetTest={resetTestProgress}
+          onGoHome={goHome}
+          registerSessionSend={registerSessionSend}
+        />
+      )}
 
-      {/* Edit View */}
       {appState.viewMode === "edit" && activeTest && (
         <EditView
           test={activeTest}
-          onUpdateSection={(index, updatedSection) => {
-            const updatedSections = [...activeTest.sections];
-            updatedSections[index] = updatedSection;
-            const updatedTests = { ...appState.tests, [activeTest.id]: { ...activeTest, sections: updatedSections } };
-            setAppState({ ...appState, tests: updatedTests });
-          }}
-          setAppState={(updaterFn) => setAppState(prevState => updaterFn(prevState))}
+          onUpdateSection={updateSection}
+          onUpdateSections={updateSections}
           onUpdateTestName={updateTestName}
+          onGoHome={goHome}
         />
       )}
     </div>
   );
 }
+

--- a/frontend/src/Types.tsx
+++ b/frontend/src/Types.tsx
@@ -27,8 +27,11 @@ export type CollaborativeSession = {
   connectedUsers: string[];
   lastSynced: number;
   sharedTestId: string;
+  userId?: string;
+  startTime?: string;
+  isAuthor?: boolean;
   /** Optional state used when the user is not the host */
-  sessionState?: any;
+  sessionState?: unknown;
 };
 
 export type Test = {

--- a/frontend/src/components/HomeButton.tsx
+++ b/frontend/src/components/HomeButton.tsx
@@ -2,16 +2,12 @@
 import "../styles/App.css";
 
 type HomeButtonProps = {
-  setAppState: (state: (prevState: any) => any) => void;
+  onGoHome: () => void;
 };
 
-export default function HomeButton({ setAppState }: HomeButtonProps) {
+export default function HomeButton({ onGoHome }: HomeButtonProps) {
   const handleHomeClick = () => {
-    setAppState((prevState) => ({
-      ...prevState,
-      viewMode: "home",
-      activeTestId: null
-    }));
+    onGoHome();
   };
 
   return (

--- a/frontend/src/sampleStates.tsx
+++ b/frontend/src/sampleStates.tsx
@@ -202,8 +202,14 @@ export const multipleTestsEditingState: AppState = {
   activeTestId: null,
   viewMode: "home",
   sessionInfo: {
+    sessionId: "sample-session",
+    token: "sample-token",
+    role: "tutor",
+    connectedUsers: [],
+    lastSynced: Date.now(),
+    sharedTestId: "",
     userId: "user-789",
     startTime: new Date().toISOString(),
-    isAuthor: true
+    isAuthor: true,
   }
 };

--- a/frontend/src/session/client.ts
+++ b/frontend/src/session/client.ts
@@ -1,9 +1,15 @@
-import type {AppState} from "../Types.tsx";
+type Highlight = {
+  id: string;
+  startIndex: number;
+  endIndex: number;
+  type: string;
+};
 
 export type SessionEvent =
   | { type: 'timer'; remaining: number }
-  | { type: 'highlight'; highlight: any }
-  | { type: 'search'; term: string };
+  | { type: 'highlight'; highlight: Highlight }
+  | { type: 'search'; term: string }
+  | { type: 'state_update'; patch: unknown };
 
 export type SessionConnection = {
   send: (event: SessionEvent) => void;

--- a/frontend/src/views/DisplayView.tsx
+++ b/frontend/src/views/DisplayView.tsx
@@ -74,9 +74,16 @@ export default function DisplayView({ test, sessionInfo, onUpdate, onResetTest, 
   const [score, setScore] = useState({ correct: 0, total: 0 });
 
   // Cleanup state when leaving display view
+
+  // without this, the useEffect happens twice on demount and you can't leave the view. Not really sure why!
+  const hasReset = useRef(false);
+
   useEffect(() => {
     return () => {
-      onResetTest(test.id);
+      if (!hasReset.current) {
+        onResetTest(test.id);
+        hasReset.current = true;
+      }
     };
   }, []);
 

--- a/frontend/src/views/EditView.tsx
+++ b/frontend/src/views/EditView.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import PassageEditor from "../components/PassageEditor";
 import QuestionEditor from "../components/QuestionEditor";
-import type {Question, Test, Section} from "../Types";
+import type { Question, Test, Section } from "../Types";
 import "../styles/App.css";
 import "../styles/EditView.css";
 import HomeButton from "../components/HomeButton.tsx";
@@ -10,11 +10,12 @@ import QuestionNavigation from "../components/QuestionNavigation.tsx";
 type Props = {
   test: Test;
   onUpdateSection: (index: number, updatedSection: Section) => void;
-  setAppState: (state: (prevState: any) => any) => void;
-  onUpdateTestName: (id:string, name:string) => void;
+  onUpdateSections: (sections: Section[]) => void;
+  onUpdateTestName: (id: string, name: string) => void;
+  onGoHome: () => void;
 };
 
-export default function EditView({ test, onUpdateSection, setAppState, onUpdateTestName }: Props) {
+export default function EditView({ test, onUpdateSection, onUpdateSections, onUpdateTestName, onGoHome }: Props) {
   // Current section and question being edited
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -107,13 +108,7 @@ export default function EditView({ test, onUpdateSection, setAppState, onUpdateT
     const newSections = [...safeSections];
     newSections.splice(sectionIndex, 1);
 
-    setAppState(prev =>
-    {
-      const tests = { ...prev.tests };
-      const current = tests[test.id];
-      tests[test.id] = { ...current, sections: newSections };
-      return { ...prev, tests };
-    })
+    onUpdateSections(newSections);
     const newSectionIndex = Math.min(sectionIndex, newSections.length - 1);
     setCurrentSectionIndex(Math.max(newSectionIndex, 0));
     setCurrentQuestionIndex(0);
@@ -188,12 +183,7 @@ const addQuestion = (sectionIndex: number, afterQuestionIndex: number) => {
   };
 
   const reorderSections = (newSections: Section[]) => {
-    setAppState(prev => {
-      const tests = { ...prev.tests };
-      const current = tests[test.id];
-      tests[test.id] = { ...current, sections: newSections };
-      return { ...prev, tests };
-    });
+    onUpdateSections(newSections);
     const movedSection = safeSections[currentSectionIndex];
     const newIdx = newSections.indexOf(movedSection);
     setCurrentSectionIndex(newIdx);
@@ -202,7 +192,7 @@ const addQuestion = (sectionIndex: number, afterQuestionIndex: number) => {
   return (
     <div style={{ display: "block" }}>
       <div className="edit-home-button">
-        <HomeButton setAppState={setAppState} />
+        <HomeButton onGoHome={onGoHome} />
       </div>
       <input
         className="heading-input"


### PR DESCRIPTION
## Summary
- centralize all app state mutations in `App.tsx` and forward them as props
- broadcast state changes over the session client when collaborative session active
- update views/components to use new handlers and simplify `HomeButton`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa59105c248325b8fa8386e9db1e8e