### PR TITLE
Refine home interface and eliminate button icons

### DIFF
--- a/frontend/src/components/QuestionDisplay.tsx
+++ b/frontend/src/components/QuestionDisplay.tsx
@@ -44,7 +44,7 @@ export default function QuestionDisplay({
                   title={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                   aria-label={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                 >
-                  {isEliminated ? "↩" : "✕"}
+                  {isEliminated ? "↺" : "✖"}
                 </button>
               )}
             </div>

--- a/frontend/src/styles/DisplayView.css
+++ b/frontend/src/styles/DisplayView.css
@@ -156,31 +156,34 @@
 
 
 .eliminate-button {
-  background-color: #444;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  width: 30px;
-  height: 30px;
-  margin-left: 10px;
+  background: transparent;
+  color: #aaa;
+  border: 1px solid #555;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  margin-left: 8px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   font-size: 14px;
 }
 
 .eliminate-button:hover {
-  background-color: #555;
+  color: #f87171;
+  border-color: #f87171;
 }
 
 .eliminate-button.active {
-  background-color: #772c2c;
+  color: #f87171;
+  border-color: #f87171;
+  background-color: rgba(248, 113, 113, 0.1);
 }
 
 .eliminate-button.active:hover {
-  background-color: #974444;
+  background-color: rgba(248, 113, 113, 0.2);
 }
 
 /* Show Answer Button */

--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -67,24 +67,70 @@ h1 {
   color: #ffffff;
 }
 
+
 .actions {
   display: flex;
-  gap: 10px;
-  margin-bottom: 15px;
+  gap: 15px;
+  margin-bottom: 20px;
 }
 
-.create-test-btn, .toggle-dropdown-btn, .upload-test-btn {
+.actions button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.create-test-btn {
   padding: 8px 15px;
-  background-color: #333;
-  color: white;
+  background-color: transparent;
+  color: #4ade80;
+  border: 1px solid #4ade80;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.create-test-btn:hover {
+  background-color: #4ade80;
+  color: #1a1a1a;
+}
+
+.upload-test-btn {
+  padding: 8px 15px;
+  background-color: transparent;
+  color: #f3f4f6;
   border: 1px solid #555;
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
-.create-test-btn:hover, .toggle-dropdown-btn:hover, .upload-test-btn:hover {
+.upload-test-btn:hover {
   background-color: #444;
+}
+
+.toggle-dropdown-btn {
+  background-color: transparent;
+  color: #f3f4f6;
+  border: 1px solid #555;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.toggle-dropdown-btn:hover {
+  background-color: #333;
+  transform: scale(1.1);
+}
+
+.icon {
+  font-size: 1.2rem;
 }
 
 /*.create-test-btn,*/

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -185,11 +185,13 @@ export default function HomeView({ appState, setAppState }: Props) {
       <div className="actions">
         {/* Create New Test Button - now toggles the creation form */}
         <button className="create-test-btn" onClick={toggleTestCreation}>
-          Create New Test
+          <span className="icon">➕</span>
+          New Test
         </button>
 
         <button className="upload-test-btn" onClick={handleUploadClick}>
-          Upload Tests
+          <span className="icon">📤</span>
+          Upload
         </button>
 
         {/* Toggle Dropdown Button (appears as "+") */}
@@ -198,7 +200,7 @@ export default function HomeView({ appState, setAppState }: Props) {
           onClick={toggleMainDropdown}
           aria-label="Toggle Dropdown"
         >
-          {mainDropdownOpen ? "-" : "+"} {/* Symbol toggles between + and - */}
+          {mainDropdownOpen ? "−" : "＋"}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Revamp home screen action buttons with icons and improved layout
- Restyle elimination toggles as compact circular icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*
- `npm run build` *(fails: TS6133 and TS2353 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ad43f3c8325ac7ae4717d8597d9