### PR TITLE
Refine home screen actions and elimination toggles

### DIFF
--- a/frontend/src/components/QuestionDisplay.tsx
+++ b/frontend/src/components/QuestionDisplay.tsx
@@ -44,7 +44,7 @@ export default function QuestionDisplay({
                   title={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                   aria-label={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                 >
-                  {isEliminated ? "↩" : "✕"}
+                  {isEliminated ? "⟳" : "⛔"}
                 </button>
               )}
             </div>

--- a/frontend/src/styles/DisplayView.css
+++ b/frontend/src/styles/DisplayView.css
@@ -155,32 +155,38 @@
 }
 
 
+.choice-container {
+  position: relative;
+}
+
 .eliminate-button {
-  background-color: #444;
-  color: #fff;
+  background: none;
   border: none;
-  border-radius: 4px;
-  width: 30px;
-  height: 30px;
-  margin-left: 10px;
+  color: #bbb;
+  width: 24px;
+  height: 24px;
+  margin-left: 6px;
+  border-radius: 50%;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s;
-  font-size: 14px;
+  font-size: 16px;
+  transition: color 0.2s, background-color 0.2s;
 }
 
 .eliminate-button:hover {
+  color: #fff;
   background-color: #555;
 }
 
 .eliminate-button.active {
-  background-color: #772c2c;
+  color: #f87171;
+  background-color: transparent;
 }
 
 .eliminate-button.active:hover {
-  background-color: #974444;
+  background-color: #772c2c;
 }
 
 /* Show Answer Button */

--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -69,12 +69,19 @@ h1 {
 
 .actions {
   display: flex;
-  gap: 10px;
-  margin-bottom: 15px;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 12px;
+  background-color: #2a2a2a;
+  border-radius: 8px;
 }
 
-.create-test-btn, .toggle-dropdown-btn, .upload-test-btn {
-  padding: 8px 15px;
+.create-test-btn,
+.upload-test-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
   background-color: #333;
   color: white;
   border: 1px solid #555;
@@ -83,8 +90,29 @@ h1 {
   transition: background-color 0.2s;
 }
 
-.create-test-btn:hover, .toggle-dropdown-btn:hover, .upload-test-btn:hover {
+.toggle-dropdown-btn {
+  width: 40px;
+  height: 40px;
+  background-color: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  transition: background-color 0.2s;
+}
+
+.create-test-btn:hover,
+.upload-test-btn:hover,
+.toggle-dropdown-btn:hover {
   background-color: #444;
+}
+
+.action-icon {
+  font-size: 18px;
 }
 
 /*.create-test-btn,*/

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -185,20 +185,22 @@ export default function HomeView({ appState, setAppState }: Props) {
       <div className="actions">
         {/* Create New Test Button - now toggles the creation form */}
         <button className="create-test-btn" onClick={toggleTestCreation}>
-          Create New Test
+          <span className="action-icon">➕</span>
+          Create Test
         </button>
 
         <button className="upload-test-btn" onClick={handleUploadClick}>
+          <span className="action-icon">📤</span>
           Upload Tests
         </button>
 
-        {/* Toggle Dropdown Button (appears as "+") */}
+        {/* Toggle Dropdown Button */}
         <button
           className="toggle-dropdown-btn"
           onClick={toggleMainDropdown}
           aria-label="Toggle Dropdown"
         >
-          {mainDropdownOpen ? "-" : "+"} {/* Symbol toggles between + and - */}
+          {mainDropdownOpen ? "▴" : "▾"}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Restyle home screen action buttons with icons and a balanced layout
- Replace bulky elimination buttons with compact icon toggles

## Testing
- `npm run lint` (fails: Unexpected any and other lint errors)
- `npm run build` (fails: TS6133 and other TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68ab8ad43f3c8325ac7ae4717d8597d9