### PR TITLE
Restyle home actions and elimination toggles

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -151,6 +151,7 @@ async def session_ws(websocket: WebSocket, session_id: str, token: str) -> None:
                     session.highlights = []
                     session.search = ""
             elif msg_type == "state_update":
+                # TODO: implement ops (e.g reset test)
                 patch = data.get("patch")
                 if isinstance(patch, dict):
                     session.state.update(patch)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,6 +161,10 @@ export default function App() {
     }
   }, []);
 
+  useEffect(() => {
+    setQuestionPos({ section: 0, question: 0 });
+  }, [appState.viewMode]);
+
   const resetTestProgress = (testId: string) => {
     const target = appState.tests[testId];
     if (!target) return;

--- a/frontend/src/components/QuestionDisplay.tsx
+++ b/frontend/src/components/QuestionDisplay.tsx
@@ -43,8 +43,9 @@ export default function QuestionDisplay({
                   }}
                   title={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                   aria-label={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
+                  aria-pressed={isEliminated}
                 >
-                  {isEliminated ? "↩" : "✕"}
+                  {isEliminated ? "↺" : "✕"}
                 </button>
               )}
             </div>

--- a/frontend/src/styles/DisplayView.css
+++ b/frontend/src/styles/DisplayView.css
@@ -156,31 +156,35 @@
 
 
 .eliminate-button {
-  background-color: #444;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  width: 30px;
-  height: 30px;
-  margin-left: 10px;
+  background: transparent;
+  color: #ddd;
+  border: 1px solid #555;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  margin-left: 8px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, color 0.2s;
   font-size: 14px;
 }
 
 .eliminate-button:hover {
   background-color: #555;
+  color: #fff;
 }
 
 .eliminate-button.active {
   background-color: #772c2c;
+  color: #fff;
+  border-color: #772c2c;
 }
 
 .eliminate-button.active:hover {
   background-color: #974444;
+  border-color: #974444;
 }
 
 /* Show Answer Button */

--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -69,13 +69,14 @@ h1 {
 
 
 .actions {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 15px;
   margin-bottom: 20px;
   width: 100%;
   max-width: 500px;
 }
+
 
 .action-btn {
   padding: 12px 15px;

--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -67,56 +67,43 @@ h1 {
   color: #ffffff;
 }
 
+
 .actions {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 15px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 15px;
+  margin-bottom: 20px;
+  width: 100%;
+  max-width: 500px;
 }
 
-.create-test-btn,
-.toggle-dropdown-btn,
-.upload-test-btn,
-.copy-link-btn {
-  padding: 8px 15px;
+.action-btn {
+  padding: 12px 15px;
   background-color: #333;
-  color: white;
+  color: #f3f4f6;
   border: 1px solid #555;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, transform 0.2s;
+  text-align: center;
 }
 
-.create-test-btn:hover,
-.toggle-dropdown-btn:hover,
-.upload-test-btn:hover,
-.copy-link-btn:hover {
+.action-btn:hover {
   background-color: #444;
+  transform: translateY(-2px);
 }
 
-/*.create-test-btn,*/
-/*.toggle-dropdown-btn {*/
-/*  font-size: 16px;*/
-/*  padding: 10px 20px;*/
-/*  border: none;*/
-/*  cursor: pointer;*/
-/*  border-radius: 4px;*/
-/*  transition: background-color 0.3s ease, transform 0.2s ease;*/
-/*}*/
-
-/*!* Toggle the toggle button (+ or -) *!*/
-/*.toggle-dropdown-btn {*/
-/*  font-size: 24px; !* Larger font size for the + or - *!*/
-/*  background: transparent;*/
-/*  border: none;*/
-/*  color: white;*/
-/*  width: 50px;*/
-/*  height: 50px;*/
-/*  border-radius: 50%;*/
-/*  display: flex;*/
-/*  justify-content: center;*/
-/*  align-items: center;*/
-/*  transition: transform 0.2s ease;*/
-/*}*/
+/* Circular toggle button */
+.toggle-dropdown-btn {
+  border-radius: 50%;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 /*.toggle-dropdown-btn:hover {*/
 /*  transform: scale(1.2); !* Enlarge slightly on hover *!*/

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -43,7 +43,6 @@ export default function HomeView({ appState, onCreateTest, onViewTest, onEditTes
     }
   };
 
-
   // Creates a new test and switches to Edit mode
   const createTest = (name: string, type: "RC" | "LR") => {
     onCreateTest(name, type);

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -189,36 +189,34 @@ export default function HomeView({ appState, onCreateTest, onViewTest, onEditTes
     <div className="home-view">
       <h1>Welcome to the Test Manager</h1>
       <div className="actions">
-
-
-      {sessionActive && (
+        {sessionActive && (
           <>
-            <button className="copy-link-btn" onClick={handleCopyLink}>
+            <button className="action-btn copy-link-btn" onClick={handleCopyLink}>
               {copySuccess ? "Copied!" : "Copy Session Link"}
             </button>
-            <button onClick={handleEndSession}>
+            <button className="action-btn" onClick={handleEndSession}>
               End Session
             </button>
           </>
-      )}
+        )}
 
         {!sessionActive && (
-          <button className="upload-test-btn" onClick={handleUploadClick}>
+          <button className="action-btn upload-test-btn" onClick={handleUploadClick}>
             Upload Tests
           </button>
         )}
 
         {!sessionActive && (
           <>
-            <button onClick={handleCreateSession}>Start Session</button>
-            <button className="create-test-btn" onClick={toggleTestCreation}>
+            <button className="action-btn" onClick={handleCreateSession}>Start Session</button>
+            <button className="action-btn create-test-btn" onClick={toggleTestCreation}>
               Create New Test
             </button>
           </>
         )}
 
         <button
-          className="toggle-dropdown-btn"
+          className="action-btn toggle-dropdown-btn"
           onClick={toggleMainDropdown}
           aria-label="Toggle Dropdown"
         >

--- a/todo.md
+++ b/todo.md
@@ -16,3 +16,4 @@ consistency in approach would probably be better.
 
 # Bugs
 - Highlighting. Selecting the correct can be frustrating, and the eraser tool can behave strangely
+- Buttons off-center after starting a session


### PR DESCRIPTION
## Summary
- Rework HomeView main actions with grid layout and shared button styling for a more balanced home screen
- Convert choice elimination controls to minimal icon buttons with active state feedback

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ed62980832583bf7b971d9e7c9a