### PR TITLE
Revamp home screen buttons and streamline elimination icons

### DIFF
--- a/frontend/src/components/QuestionDisplay.tsx
+++ b/frontend/src/components/QuestionDisplay.tsx
@@ -44,7 +44,7 @@ export default function QuestionDisplay({
                   title={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                   aria-label={isEliminated ? "Restore answer choice" : "Eliminate answer choice"}
                 >
-                  {isEliminated ? "↩" : "✕"}
+                  {isEliminated ? "↺" : "✕"}
                 </button>
               )}
             </div>

--- a/frontend/src/styles/DisplayView.css
+++ b/frontend/src/styles/DisplayView.css
@@ -156,31 +156,31 @@
 
 
 .eliminate-button {
-  background-color: #444;
-  color: #fff;
+  background: none;
   border: none;
-  border-radius: 4px;
-  width: 30px;
-  height: 30px;
-  margin-left: 10px;
+  margin-left: 8px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s;
-  font-size: 14px;
+  width: 24px;
+  height: 24px;
+  color: #f87171;
+  font-size: 1rem;
+  border-radius: 50%;
+  transition: transform 0.2s, color 0.2s;
 }
 
 .eliminate-button:hover {
-  background-color: #555;
+  transform: scale(1.2);
 }
 
 .eliminate-button.active {
-  background-color: #772c2c;
+  color: #4ade80;
 }
 
 .eliminate-button.active:hover {
-  background-color: #974444;
+  transform: scale(1.2);
 }
 
 /* Show Answer Button */

--- a/frontend/src/styles/HomeView.css
+++ b/frontend/src/styles/HomeView.css
@@ -67,30 +67,51 @@ h1 {
   color: #ffffff;
 }
 
+
 .actions {
   display: flex;
-  gap: 10px;
-  margin-bottom: 15px;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 15px;
+  margin-bottom: 20px;
+  width: 100%;
+  max-width: 600px;
 }
 
-.create-test-btn,
-.toggle-dropdown-btn,
-.upload-test-btn,
-.copy-link-btn {
-  padding: 8px 15px;
-  background-color: #333;
-  color: white;
-  border: 1px solid #555;
-  border-radius: 4px;
+.action-btn {
+  padding: 12px 20px;
+  background-color: #2d2d2d;
+  color: #f3f4f6;
+  border: 1px solid #444;
+  border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.create-test-btn:hover,
-.toggle-dropdown-btn:hover,
-.upload-test-btn:hover,
-.copy-link-btn:hover {
-  background-color: #444;
+.action-btn:hover {
+  background-color: #3a3a3a;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.icon {
+  font-size: 1.1rem;
+}
+
+.toggle-dropdown-btn {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  line-height: 1;
+  font-size: 1.5rem;
 }
 
 /*.create-test-btn,*/

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -189,40 +189,45 @@ export default function HomeView({ appState, onCreateTest, onViewTest, onEditTes
     <div className="home-view">
       <h1>Welcome to the Test Manager</h1>
       <div className="actions">
-
-
-      {sessionActive && (
+        {sessionActive && (
           <>
-            <button className="copy-link-btn" onClick={handleCopyLink}>
+            <button className="action-btn copy-link-btn" onClick={handleCopyLink}>
+              <span className="icon">⧉</span>
               {copySuccess ? "Copied!" : "Copy Session Link"}
             </button>
-            <button onClick={handleEndSession}>
+            <button className="action-btn end-session-btn" onClick={handleEndSession}>
+              <span className="icon">■</span>
               End Session
             </button>
           </>
-      )}
+        )}
 
         {!sessionActive && (
-          <button className="upload-test-btn" onClick={handleUploadClick}>
+          <button className="action-btn upload-test-btn" onClick={handleUploadClick}>
+            <span className="icon">↑</span>
             Upload Tests
           </button>
         )}
 
         {!sessionActive && (
           <>
-            <button onClick={handleCreateSession}>Start Session</button>
-            <button className="create-test-btn" onClick={toggleTestCreation}>
+            <button className="action-btn start-session-btn" onClick={handleCreateSession}>
+              <span className="icon">▶</span>
+              Start Session
+            </button>
+            <button className="action-btn create-test-btn" onClick={toggleTestCreation}>
+              <span className="icon">✎</span>
               Create New Test
             </button>
           </>
         )}
 
         <button
-          className="toggle-dropdown-btn"
+          className="action-btn toggle-dropdown-btn"
           onClick={toggleMainDropdown}
           aria-label="Toggle Dropdown"
         >
-          {mainDropdownOpen ? "-" : "+"}
+          {mainDropdownOpen ? "−" : "+"}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Restyled home screen action buttons with icons, grid layout, and hover effects for a more balanced look.
- Replaced bulky elimination toggles with icon-only buttons that signal eliminate/restore states.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ed62980832583bf7b971d9e7c9a